### PR TITLE
add user_dict api support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.retrofit)
     implementation(libs.retrofitConverterGson)
+    implementation(libs.retrofitConverterScalars)
     implementation(libs.serialization)
     testImplementation(libs.coroutinesTest)
     testImplementation(libs.koin)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ koin = "3.4.1"
 [libraries]
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 retrofitConverterGson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
+retrofitConverterScalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }

--- a/src/main/kotlin/com/github/kitakkun/ktvox/api/dictionary/DictApi.kt
+++ b/src/main/kotlin/com/github/kitakkun/ktvox/api/dictionary/DictApi.kt
@@ -1,24 +1,40 @@
 package com.github.kitakkun.ktvox.api.dictionary
 
-import retrofit2.http.DELETE
-import retrofit2.http.GET
-import retrofit2.http.POST
-import retrofit2.http.PUT
+import com.github.kitakkun.ktvox.schema.dictionary.UserDictWord
+import retrofit2.Response
+import retrofit2.http.*
 
-// TODO
 interface DictApi {
     @GET("/user_dict")
-    suspend fun getUserDict(): String
+    suspend fun getUserDict(): Response<Map<String, UserDictWord>>
 
     @POST("/user_dict_word")
-    suspend fun addUserDictWord(): String
+    suspend fun addUserDictWord(
+        @Query("surface") surface: String,
+        @Query("pronunciation") pronunciation: String,
+        @Query("accent_type") accentType: Int,
+        @Query("word_type") wordType: String? = null,
+        @Query("priority") priority: Int? = null,
+    ): Response<String>
 
     @PUT("/user_dict_word/{word_uuid}")
-    suspend fun updateUserDictWord(): String
+    suspend fun rewriteUserDictWord(
+        @Path("word_uuid") wordUuid: String,
+        @Query("surface") surface: String,
+        @Query("pronunciation") pronunciation: String,
+        @Query("accent_type") accentType: Int,
+        @Query("word_type") wordType: String? = null,
+        @Query("priority") priority: Int? = null,
+    ): Response<Unit>
 
     @DELETE("/user_dict_word/{word_uuid}")
-    suspend fun deleteUserDictWord(): String
+    suspend fun deleteUserDictWord(
+        @Path("word_uuid") wordUuid: String,
+    ): Response<Unit>
 
     @POST("/import_user_dict")
-    suspend fun importUserDict(): String
+    suspend fun importUserDict(
+        @Query("override") override: Boolean,
+        @Body importDictData: Map<String, UserDictWord>,
+    ): Response<Unit>
 }

--- a/src/main/kotlin/com/github/kitakkun/ktvox/schema/dictionary/UserDictWord.kt
+++ b/src/main/kotlin/com/github/kitakkun/ktvox/schema/dictionary/UserDictWord.kt
@@ -1,0 +1,34 @@
+package com.github.kitakkun.ktvox.schema.dictionary
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserDictWord(
+    val surface: String,
+    val priority: Int,
+    @SerializedName("context_id")
+    val contextId: Int?,
+    @SerializedName("part_of_speech")
+    val partOfSpeech: String,
+    @SerializedName("part_of_speech_detail_1")
+    val partOfSpeechDetail1: String,
+    @SerializedName("part_of_speech_detail_2")
+    val partOfSpeechDetail2: String,
+    @SerializedName("part_of_speech_detail_3")
+    val partOfSpeechDetail3: String,
+    @SerializedName("inflectional_type")
+    val inflectionalType: String,
+    @SerializedName("inflectional_form")
+    val inflectionalForm: String,
+    val stem: String,
+    val yomi: String,
+    val pronunciation: String,
+    @SerializedName("accent_type")
+    val accentType: Int,
+    @SerializedName("mora_count")
+    val moraCount: Int?,
+    @SerializedName("accent_associative_rule")
+    val accentAssociativeRule: String?,
+)
+

--- a/src/test/kotlin/com/github/kitakkun/ktvox/DictApiTest.kt
+++ b/src/test/kotlin/com/github/kitakkun/ktvox/DictApiTest.kt
@@ -1,0 +1,56 @@
+package com.github.kitakkun.ktvox
+
+import com.github.kitakkun.ktvox.api.dictionary.DictApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.koin.test.inject
+
+class DictApiTest : BaseKtVoxApiTest() {
+    private val api: DictApi by inject()
+
+    @Test
+    fun testGetDict() = runTest {
+        val response = api.getUserDict()
+        assert(response.isSuccessful)
+    }
+
+    @Test
+    fun testAddDictWord() = runTest {
+        val response = api.addUserDictWord(
+            surface = "こんにちは",
+            pronunciation = "コンニチハ",
+            accentType = 0,
+        )
+        assert(response.isSuccessful)
+        val uuid = response.body() ?: throw Exception("uuid is null")
+        api.deleteUserDictWord(uuid)
+    }
+
+    @Test
+    fun testRewriteDictWord() = runTest {
+        val uuid = api.addUserDictWord(
+            surface = "こんにちは",
+            pronunciation = "コンニチハ",
+            accentType = 0,
+        ).body() ?: throw Exception("uuid is null")
+        val response = api.rewriteUserDictWord(
+            wordUuid = uuid,
+            surface = "こんにちは",
+            pronunciation = "コンニチハハハハ",
+            accentType = 0,
+        )
+        assert(response.isSuccessful)
+        api.deleteUserDictWord(uuid)
+    }
+
+    @Test
+    fun testDeleteDictWord() = runTest {
+        val uuid = api.addUserDictWord(
+            surface = "こんにちは",
+            pronunciation = "コンニチハ",
+            accentType = 0,
+        ).body() ?: throw Exception("uuid is null")
+        val response = api.deleteUserDictWord(uuid)
+        assert(response.isSuccessful)
+    }
+}

--- a/src/test/kotlin/com/github/kitakkun/ktvox/module/KtVoxModule.kt
+++ b/src/test/kotlin/com/github/kitakkun/ktvox/module/KtVoxModule.kt
@@ -1,5 +1,6 @@
 package com.github.kitakkun.ktvox.module
 
+import com.github.kitakkun.ktvox.api.dictionary.DictApi
 import com.github.kitakkun.ktvox.api.extra.ExtraApi
 import com.github.kitakkun.ktvox.api.query.QueryApi
 import com.github.kitakkun.ktvox.api.query.QueryCreateApi
@@ -25,4 +26,5 @@ val ktVoxModule = module {
     factory<QueryCreateApi> { get<Retrofit>().create() }
     factory<SynthApi> { get<Retrofit>().create() }
     factory<ExtraApi> { get<Retrofit>().create() }
+    factory<DictApi> { get<Retrofit>().create() }
 }

--- a/src/test/kotlin/com/github/kitakkun/ktvox/module/KtVoxModule.kt
+++ b/src/test/kotlin/com/github/kitakkun/ktvox/module/KtVoxModule.kt
@@ -8,12 +8,14 @@ import com.github.kitakkun.ktvox.api.synth.SynthApi
 import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.create
 
 val ktVoxModule = module {
     single<Retrofit> {
         Retrofit.Builder()
             .baseUrl("http://127.0.0.1:50021")
+            .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }


### PR DESCRIPTION
次のAPIのサポートを追加します．
- GET: `/user_dict` ユーザ辞書に登録されている単語一覧の取得
- POST: `/user_dict_word` 単語登録
- PUT: `/user_dict_word/{word_uuid}` 単語更新
- DELETE: `/user_dict_word/{word_uuid}` 単語削除
- POST: `/import_user_dict` 辞書インポート（※未テスト）