### PR TITLE
fix DictApi unavailable via KtVoxApi

### DIFF
--- a/src/main/kotlin/com/github/kitakkun/ktvox/api/KtVoxApi.kt
+++ b/src/main/kotlin/com/github/kitakkun/ktvox/api/KtVoxApi.kt
@@ -1,7 +1,8 @@
 package com.github.kitakkun.ktvox.api
 
+import com.github.kitakkun.ktvox.api.dictionary.DictApi
 import com.github.kitakkun.ktvox.api.extra.ExtraApi
 import com.github.kitakkun.ktvox.api.query.QueryApi
 import com.github.kitakkun.ktvox.api.synth.SynthApi
 
-interface KtVoxApi : QueryApi, SynthApi, ExtraApi
+interface KtVoxApi : QueryApi, SynthApi, ExtraApi, DictApi


### PR DESCRIPTION
ユーザ辞書のAPIがKtVoxApiに含まれていなかったので追加します