### PR TITLE
Fix tests / Fix SettingApi, DictApi

### DIFF
--- a/src/main/kotlin/com/github/kitakkun/ktvox/api/KtVoxApi.kt
+++ b/src/main/kotlin/com/github/kitakkun/ktvox/api/KtVoxApi.kt
@@ -3,11 +3,12 @@ package com.github.kitakkun.ktvox.api
 import com.github.kitakkun.ktvox.api.dictionary.DictApi
 import com.github.kitakkun.ktvox.api.extra.ExtraApi
 import com.github.kitakkun.ktvox.api.query.QueryApi
+import com.github.kitakkun.ktvox.api.setting.SettingApi
 import com.github.kitakkun.ktvox.api.synth.SynthApi
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 
-interface KtVoxApi : QueryApi, SynthApi, ExtraApi, DictApi {
+interface KtVoxApi : QueryApi, SynthApi, ExtraApi, DictApi, SettingApi {
     companion object {
         fun initialize(serverUrl: String): KtVoxApi {
             val retrofit = retrofit2.Retrofit.Builder()

--- a/src/main/kotlin/com/github/kitakkun/ktvox/api/setting/SettingApi.kt
+++ b/src/main/kotlin/com/github/kitakkun/ktvox/api/setting/SettingApi.kt
@@ -1,11 +1,8 @@
 package com.github.kitakkun.ktvox.api.setting
 
 import com.github.kitakkun.ktvox.annotation.ExperimentalKtVoxApi
-import okhttp3.RequestBody
 import retrofit2.Response
-import retrofit2.http.Body
-import retrofit2.http.GET
-import retrofit2.http.POST
+import retrofit2.http.*
 
 interface SettingApi {
     @ExperimentalKtVoxApi
@@ -13,8 +10,10 @@ interface SettingApi {
     suspend fun getSetting(): Response<String>
 
     @ExperimentalKtVoxApi
+    @FormUrlEncoded
     @POST("/setting")
     suspend fun postSetting(
-        @Body requestBody: RequestBody,
+        @Field("cors_policy_mode") corsPolicyMode: String,
+        @Field("allow_origin") allowOrigin: List<String>,
     ): Response<String>
 }

--- a/src/main/kotlin/com/github/kitakkun/ktvox/api/synth/SynthApi.kt
+++ b/src/main/kotlin/com/github/kitakkun/ktvox/api/synth/SynthApi.kt
@@ -21,7 +21,7 @@ interface SynthApi {
 
     @ExperimentalKtVoxApi
     @POST("/cancellable_synthesis")
-    suspend fun postCancellableSynthesis(
+    fun postCancellableSynthesis(
         @Query("speaker") speaker: Int,
         @Query("core_version") coreVersion: String? = null,
         @Body audioQuery: AudioQuery,

--- a/src/test/kotlin/com/github/kitakkun/ktvox/BaseKtVoxApiTest.kt
+++ b/src/test/kotlin/com/github/kitakkun/ktvox/BaseKtVoxApiTest.kt
@@ -19,6 +19,21 @@ abstract class BaseKtVoxApiTest : KoinTest {
     fun setup() {
         container = GenericContainer<Nothing>(imageName)
             .withExposedPorts(50021)
+        // FYI: https://hub.docker.com/layers/voicevox/voicevox_engine/cpu-ubuntu20.04-latest/images/sha256-f210f09d2307acbb0e95457dbe654c8f770df718432f5854b4064e2334c6b98c?context=explore
+        container.setCommand(
+            "gosu",
+            "user",
+            "/opt/python/bin/python3",
+            "./run.py",
+            "--voicelib_dir",
+            "/opt/voicevox_core/",
+            "--runtime_dir",
+            "/opt/onnxruntime/lib",
+            "--host",
+            "0.0.0.0",
+            "--enable_cancellable_synthesis", // experimental api (for test)
+            "--enable_mock" // make tests run faster
+        )
         container.start()
         val host = container.host
         val port = container.getMappedPort(50021)

--- a/src/test/kotlin/com/github/kitakkun/ktvox/DictApiTest.kt
+++ b/src/test/kotlin/com/github/kitakkun/ktvox/DictApiTest.kt
@@ -22,8 +22,6 @@ class DictApiTest : BaseKtVoxApiTest() {
             accentType = 0,
         )
         assert(response.isSuccessful)
-        val uuid = response.body() ?: throw Exception("uuid is null")
-        api.deleteUserDictWord(uuid)
     }
 
     @Test
@@ -40,7 +38,6 @@ class DictApiTest : BaseKtVoxApiTest() {
             accentType = 0,
         )
         assert(response.isSuccessful)
-        api.deleteUserDictWord(uuid)
     }
 
     @Test

--- a/src/test/kotlin/com/github/kitakkun/ktvox/DictApiTest.kt
+++ b/src/test/kotlin/com/github/kitakkun/ktvox/DictApiTest.kt
@@ -1,6 +1,7 @@
 package com.github.kitakkun.ktvox
 
 import com.github.kitakkun.ktvox.api.dictionary.DictApi
+import com.github.kitakkun.ktvox.schema.dictionary.UserDictWord
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
@@ -48,6 +49,34 @@ class DictApiTest : BaseKtVoxApiTest() {
             accentType = 0,
         ).body() ?: throw Exception("uuid is null")
         val response = api.deleteUserDictWord(uuid)
+        assert(response.isSuccessful)
+    }
+
+    @Test
+    fun testImportUserDict() = runTest {
+        val userDict = mapOf(
+            "e2acc2ef-e08b-42d3-9bab-b79e51c458c7" to UserDictWord(
+                surface = "こんにちは",
+                priority = 5,
+                contextId = 1348,
+                partOfSpeech = "名詞",
+                partOfSpeechDetail1 = "固有名詞",
+                partOfSpeechDetail2 = "一般",
+                partOfSpeechDetail3 = "*",
+                inflectionalType = "*",
+                inflectionalForm = "*",
+                stem = "*",
+                yomi = "コンニチハ",
+                pronunciation = "コンニチハ",
+                accentType = 0,
+                moraCount = 5,
+                accentAssociativeRule = "*",
+            )
+        )
+        val response = api.importUserDict(
+            override = true,
+            importDictData = userDict
+        )
         assert(response.isSuccessful)
     }
 }

--- a/src/test/kotlin/com/github/kitakkun/ktvox/ExtraApiTest.kt
+++ b/src/test/kotlin/com/github/kitakkun/ktvox/ExtraApiTest.kt
@@ -88,7 +88,6 @@ class ExtraApiTest : BaseKtVoxApiTest() {
         val response = extraApi.addPreset(preset)
         if (response.code() == 500) return@runTest
         assert(response.isSuccessful)
-        extraApi.deletePreset(response.body()!!)
     }
 
     @Test
@@ -111,7 +110,6 @@ class ExtraApiTest : BaseKtVoxApiTest() {
         val response2 = extraApi.updatePreset(preset.copy(id = presetId, name = "updated"))
         if (response2.code() == 500) return@runTest
         assert(response2.isSuccessful)
-        extraApi.deletePreset(presetId)
     }
 
     @Test

--- a/src/test/kotlin/com/github/kitakkun/ktvox/SettingTest.kt
+++ b/src/test/kotlin/com/github/kitakkun/ktvox/SettingTest.kt
@@ -1,0 +1,29 @@
+package com.github.kitakkun.ktvox
+
+import com.github.kitakkun.ktvox.annotation.ExperimentalKtVoxApi
+import com.github.kitakkun.ktvox.api.setting.SettingApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.koin.core.component.inject
+
+class SettingTest : BaseKtVoxApiTest() {
+    private val api: SettingApi by inject()
+
+    @OptIn(ExperimentalKtVoxApi::class)
+    @Test
+    fun testGetSetting() = runTest {
+        val response = api.getSetting()
+        println(response.body())
+        assert(response.isSuccessful)
+    }
+
+    @OptIn(ExperimentalKtVoxApi::class)
+    @Test
+    fun testPostSetting() = runTest {
+        val response = api.postSetting(
+            corsPolicyMode = "localapps",
+            allowOrigin = listOf("http://localhost:3000", "http://localhost:8080"),
+        )
+        assert(response.isSuccessful)
+    }
+}

--- a/src/test/kotlin/com/github/kitakkun/ktvox/SynthTest.kt
+++ b/src/test/kotlin/com/github/kitakkun/ktvox/SynthTest.kt
@@ -1,5 +1,6 @@
 package com.github.kitakkun.ktvox
 
+import com.github.kitakkun.ktvox.annotation.ExperimentalKtVoxApi
 import com.github.kitakkun.ktvox.api.query.QueryApi
 import com.github.kitakkun.ktvox.api.synth.SynthApi
 import kotlinx.coroutines.test.runTest
@@ -27,6 +28,22 @@ class SynthTest : BaseKtVoxApiTest() {
         // val file = File("output.wav")
         // val bytes = response.body()?.bytes() ?: throw Exception("body is null")
         // file.writeBytes(bytes)
+    }
+
+    @OptIn(ExperimentalKtVoxApi::class)
+    @Test
+    fun testPostCancellableSynthesis() = runTest {
+        val query = queryApi.createAudioQuery(
+            text = "こんにちは",
+            speaker = 0,
+        ).body()
+        assertNotNull(query)
+        val response = synthApi.postCancellableSynthesis(
+            speaker = 0,
+            audioQuery = query,
+        )
+        response.cancel()
+        assert(response.isCanceled)
     }
 
     @Test

--- a/src/test/kotlin/com/github/kitakkun/ktvox/module/KtVoxModule.kt
+++ b/src/test/kotlin/com/github/kitakkun/ktvox/module/KtVoxModule.kt
@@ -5,6 +5,7 @@ import com.github.kitakkun.ktvox.api.extra.ExtraApi
 import com.github.kitakkun.ktvox.api.query.QueryApi
 import com.github.kitakkun.ktvox.api.query.QueryCreateApi
 import com.github.kitakkun.ktvox.api.query.QueryEditApi
+import com.github.kitakkun.ktvox.api.setting.SettingApi
 import com.github.kitakkun.ktvox.api.synth.SynthApi
 import org.koin.dsl.module
 import retrofit2.Retrofit
@@ -27,4 +28,5 @@ fun ktVoxModule(baseUrl: String) = module {
     factory<SynthApi> { get<Retrofit>().create() }
     factory<ExtraApi> { get<Retrofit>().create() }
     factory<DictApi> { get<Retrofit>().create() }
+    factory<SettingApi> { get<Retrofit>().create() }
 }


### PR DESCRIPTION
## New Features
- `SettingApi` now supported! (but getSettings require local html parsing)
- `SynthApi` now supports `postCancellableSynthesis`!

## Fixed Tests
- `DictApi` test for `importUserDict` added
- `SettingApi` added
- `SynthApi` test for `postCancellableSynthesis` added

## Note
`/connect_waves` is not verified for now.